### PR TITLE
Actually test the parsing

### DIFF
--- a/OxfordTests/OxfordTests.swift
+++ b/OxfordTests/OxfordTests.swift
@@ -14,9 +14,11 @@ class OxfordTests: XCTestCase {
     // TODO: Use Swiftcheck like a boss
     func testBasicParsing() {
         let csv = try! CSV(path: NSBundle(forClass: OxfordTests.self).URLForResource("test", withExtension: "csv")!.path!)
-        for line in csv.rows {
-            print(line)
-        }
+        let expected = [
+            ["One": "1", "Three": "3", "Two": "2"],
+            ["One": "4", "Three": "6", "Two": "5"]
+        ]
+        XCTAssert(csv.rows.elementsEqual(expected, isEquivalent: ==))
     }
     
 }


### PR DESCRIPTION
`testBasicParsing` should use `XCTAssert` to check if the CSV parsing is correct i.e. _actually_ test the parsing.
