### PR TITLE
CSVSequence struct does it all, no need for separate CSV class

### DIFF
--- a/OxfordTests/OxfordTests.swift
+++ b/OxfordTests/OxfordTests.swift
@@ -13,12 +13,12 @@ class OxfordTests: XCTestCase {
     
     // TODO: Use Swiftcheck like a boss
     func testBasicParsing() {
-        let csv = try! CSV(path: NSBundle(forClass: OxfordTests.self).URLForResource("test", withExtension: "csv")!.path!)
+        let csv = try! CSVSequence(path: NSBundle(forClass: OxfordTests.self).URLForResource("test", withExtension: "csv")!.path!)
         let expected = [
             ["One": "1", "Three": "3", "Two": "2"],
             ["One": "4", "Three": "6", "Two": "5"]
         ]
-        XCTAssert(csv.rows.elementsEqual(expected, isEquivalent: ==))
+        XCTAssert(csv.elementsEqual(expected, isEquivalent: ==))
     }
     
 }


### PR DESCRIPTION
`CSV` seems mostly a simple wrapper around `CSVSequence`, in which case it's cleaner to just have `CSVSequence` and initialize it appropriately.

Also fixes the `all stored properties of a class instance must be initialized before throwing from an initializer` compiler complaint when class not initialised. Not directly related, it's probably because the original `CSV.init` was a designated initializer not a delegating one.
